### PR TITLE
Experimental shortcode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,17 @@ Once you've entered your GearLab Tools settings, but before enabling overriding 
 
 Once you've entered the settings above correctly, you're ready to enable GearLab Tools Search to override the default WP search. Enable the option **Override default WordPress search** and save the settings again. You should now see a basic search results page rendered by GearLab Tools whenever you perform a search.
 
-**IMPORTANT: This plugin currently only works "out of the box" with the Timber library enabled.** A less opinionated, dependency-free workflow based on shortcodes is planned. For now, you must either use the default Timber-rendered markup (see the `views` directory) or override them from your theme.
+#### Search Shortcode
+
+Out of the box, you can use the `[gearlab_search]` shortcode in any RTE that supports shortcodes. This is the recommended approach for most cases.
+
+However, basic searches (using WordPress's standard `s` query param), will still render your theme's default search.php template (assuming there is one). You can redirect global searches to the page your shortcode lives on in the Settings. Go to **Settings > GearLab Tools** and select **Redirect searches to a specific page**. Type the URI, e.g. `/search`, in the text box that appears.
+
+Save your changes and you're good to go! Default searches will now redirect to your page. Note that all query string parameters will be preserved *except* `s`, which will be renamed to `glt_search` to avoid conflicting with WordPress's default functionality.
 
 #### Overriding Timber templates
+
+This plugin has special support for [Timber](https://www.upstatement.com/timber/).
 
 To override how Timber renders your search results, you can add Theme Overrides. These are files that the plugin looks for in your theme and loads it if finds them, falling back to the plugin's own templates if it does not. These files are (relative to your theme root):
 

--- a/css/gearlab-tools-admin.css
+++ b/css/gearlab-tools-admin.css
@@ -1,3 +1,22 @@
+.glt-field {
+  margin: 1em 0;
+}
+.glt-field--flex {
+  display: flex;
+}
+.glt-field__label {
+  width: 20%;
+}
+.glt-field__input {
+  width: 80%;
+}
 .glt-field input[type=text] {
   width: 100%;
+}
+textarea.glt-shortcode-text {
+  color: black;
+  font-weight: 700;
+  border: none;
+  height: 2em;
+  width: 16ch;
 }

--- a/css/gearlab-tools-search.css
+++ b/css/gearlab-tools-search.css
@@ -14,6 +14,9 @@
 .glt-search-card__snippet{ margin: 0 0 20px 0; }
 .glt-search-card__link{ font-weight: 700; }
 
+.ui-autocomplete .ui-menu-item {
+  padding: 3px 7px;
+}
 .ui-autocomplete .ui-state-focus {
   border: none;
   background: #c6c6c6;

--- a/css/gearlab-tools-search.css
+++ b/css/gearlab-tools-search.css
@@ -13,3 +13,8 @@
 .glt-search-card__title{ margin: 0 0 15px 0; }
 .glt-search-card__snippet{ margin: 0 0 20px 0; }
 .glt-search-card__link{ font-weight: 700; }
+
+.ui-autocomplete .ui-state-focus {
+  border: none;
+  background: #c6c6c6;
+}

--- a/gearlab-tools.php
+++ b/gearlab-tools.php
@@ -170,12 +170,24 @@ add_filter('gearlab/render', function($tpl, $data = []) {
 add_action('init', function() {
   global $wp;
   $wp->add_query_var('glt_search');
+  $wp->add_query_var('glt_meta_tag');
+  $wp->add_query_var('glt_page_num');
 
   add_shortcode('gearlab_search', function($atts = []) {
     global $post;
 
+    // Override how search paramaters are set in shortcode context.
     add_filter('gearlab/search/query', function() {
       return get_query_var('glt_search');
+    });
+    add_filter('gearlab/search/meta_tag', function() {
+      return get_query_var('glt_meta_tag');
+    });
+    add_filter('gearlab/search/page_num', function() {
+      return get_query_var('glt_page_num') ?: 1;
+    });
+    add_filter('gearlab/search/page_num_param', function() {
+      return 'glt_page_num';
     });
 
     $searchQuery = apply_filters('gearlab/search/query', '');

--- a/gearlab-tools.php
+++ b/gearlab-tools.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://gearlab.tools
  * Author: Coby Tamayo <ctamayo@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 1.0.2
+ * Version: 1.1.0
  */
 
 // no script kiddiez

--- a/gearlab-tools.php
+++ b/gearlab-tools.php
@@ -40,6 +40,10 @@ define('GEARLAB_PLUGIN_WEB_PATH', plugin_dir_url(__FILE__));
 define('GEARLAB_PLUGIN_JS_ROOT', GEARLAB_PLUGIN_WEB_PATH . 'js');
 define('GEARLAB_PLUGIN_VIEW_PATH', __DIR__ . '/views');
 
+// "1" for backwards compatibility, from when this was a single toggle setting
+define('GEARLAB_OVERRIDE_METHOD_TIMBER', '1');
+define('GEARLAB_OVERRIDE_METHOD_SHORTCODE', 'shortcode');
+
 /*
  * Add the main hook for getting an API client instance
  */
@@ -74,6 +78,7 @@ add_action('admin_menu', function() {
       'gearlab_collection_id',
       'gearlab_base_uri',
       'gearlab_search_enabled',
+      'gearlab_search_redirect',
     ],
   ]);
   // Process any user updates
@@ -213,5 +218,26 @@ add_action('init', function() {
       'query'    => $searchQuery,
       'response' => $response,
     ]);
+  });
+
+  /*
+   * Redirect to the configured search page
+   */
+  add_action('template_redirect', function() {
+    if (!GearLab\shortcode_redirect_enabled()) {
+      return;
+    }
+
+    global $wp_query;
+    $dest = get_option('gearlab_search_redirect');
+    if ($dest && $wp_query->is_search()) {
+      $params = array_merge($_GET, [
+        'glt_search' => get_query_var('s')
+      ]);
+      unset($params['s']);
+
+      wp_redirect($dest . '?' . http_build_query($params));
+      exit;
+    }
   });
 });

--- a/gearlab-tools.php
+++ b/gearlab-tools.php
@@ -6,7 +6,7 @@
  * Plugin URI: https://gearlab.tools
  * Author: Coby Tamayo <ctamayo@sitecrafting.com>
  * Author URI: https://www.sitecrafting.com/
- * Version: 1.1.0
+ * Version: 1.2.0
  */
 
 // no script kiddiez

--- a/js/search.js
+++ b/js/search.js
@@ -2,7 +2,7 @@ jQuery(function($) {
 
   // Assume for now that the search input is the sole form field with a
   // name="s" attribute
-  var $ac = $('form [name="s"]').autocomplete({
+  var $ac = $('form [name="s"], form [name="glt_search"]').autocomplete({
     source: '/wp-json/gearlab/v2/completions',
     minLength: 3,
   });

--- a/src/Paginator.php
+++ b/src/Paginator.php
@@ -19,11 +19,12 @@ class Paginator {
     $count     = apply_filters('gearlab/search/result_count', 10);
     $pageCount = ceil((int) ($response['total'] ?? 0) / $count);
     $page      = apply_filters('gearlab/search/page_num', 1);
+    $pageParam = apply_filters('gearlab/search/page_num_param', 'page_num');
 
     $paginator->set_pagination([
       'page_count'          => $pageCount,
       'current_page_number' => $page,
-      // TODO filter for param_name
+      'param_name'          => $pageParam,
     ]);
 
     return $paginator;

--- a/views/frontend/search-result.php
+++ b/views/frontend/search-result.php
@@ -6,7 +6,7 @@ $result = $data['result'] ?? [];
 <div class="glt-search-card">
 	<?php // If filtering by post_type using metaTag, this is where that data will show up ?>
   <?php if (!empty($result['meta']['tags']) && is_array($result['meta']['tags'])): ?>
-		<div class="glt-search-card__label"><?= implode(', ', apply_filters('gearlab/metatag/human_readable', $result['meta']['tags'])) ?></div>
+		<div class="glt-search-card__label"><?= implode(', ', apply_filters('gearlab/meta_tag/human_readable', $result['meta']['tags'])) ?></div>
   <?php endif; ?>
 	<h3 class="glt-search-card__title"><?= $result['title'] ?></h3>
 	<div class="glt-search-card__snippet"><?= $result['snippet'] ?></div>

--- a/views/frontend/search-result.php
+++ b/views/frontend/search-result.php
@@ -6,7 +6,13 @@ $result = $data['result'] ?? [];
 <div class="glt-search-card">
 	<?php // If filtering by post_type using metaTag, this is where that data will show up ?>
   <?php if (!empty($result['meta']['tags']) && is_array($result['meta']['tags'])): ?>
-		<div class="glt-search-card__label"><?= implode(', ', apply_filters('gearlab/meta_tag/human_readable', $result['meta']['tags'])) ?></div>
+		<?php foreach ($result['meta']['tags'] as $tag) : ?>
+			<div class="glt-search-card__label"><?= apply_filters(
+				'gearlab/search/result/meta_tag_label',
+				$tag,
+				$result
+			) ?></div>
+		<?php endforeach; ?>
   <?php endif; ?>
 	<h3 class="glt-search-card__title"><?= $result['title'] ?></h3>
 	<div class="glt-search-card__snippet"><?= $result['snippet'] ?></div>

--- a/views/frontend/search-result.php
+++ b/views/frontend/search-result.php
@@ -1,0 +1,14 @@
+<?php
+
+$result = $data['result'] ?? [];
+
+?>
+<div class="glt-search-card">
+	<?php // If filtering by post_type using metaTag, this is where that data will show up ?>
+  <?php if (!empty($result['meta']['tags']) && is_array($result['meta']['tags'])): ?>
+		<div class="glt-search-card__label"><?= implode(', ', apply_filters('gearlab/metatag/human_readable', $result['meta']['tags'])) ?></div>
+  <?php endif; ?>
+	<h3 class="glt-search-card__title"><?= $result['title'] ?></h3>
+	<div class="glt-search-card__snippet"><?= $result['snippet'] ?></div>
+	<a class="glt-search-card__link" href="<?= $result['url'] ?>">Learn More</a>
+</div>

--- a/views/frontend/search-results.php
+++ b/views/frontend/search-results.php
@@ -13,7 +13,7 @@ $searchQuery = $data['query'] ?? '';
   <div class="container">
     <div class="global-search">
       <h5>Search</h5>
-      <form role="search" method="get" id="searchform" class="searchform" action="<?= get_permalink($post) ?>">
+      <form role="search" method="get" id="searchform" class="searchform glt-search-form" action="<?= get_permalink($post) ?>">
         <input
           type="text"
           value="<?= $searchQuery ?>"

--- a/views/frontend/search-results.php
+++ b/views/frontend/search-results.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Generic search results page, powered by Timber
+ * Generic search results page content
  */
 
 $response    = $data['response'] ?? [];

--- a/views/frontend/search-results.php
+++ b/views/frontend/search-results.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Generic search results page, powered by Timber
+ */
+
+$response    = $data['response'] ?? [];
+$post        = $data['post'] ?? $GLOBALS['post'] ?? null;
+$searchQuery = $data['query'] ?? '';
+
+?>
+<section class="glt-search-form-container">
+  <div class="container">
+    <div class="global-search">
+      <h5>Search</h5>
+      <form role="search" method="get" id="searchform" class="searchform" action="<?= get_permalink($post) ?>">
+        <input
+          type="text"
+          value="<?= $searchQuery ?>"
+          name="glt_search"
+          id="search-term"
+          placeholder="Enter keyword or phrase"
+          title="Enter keyword or phrase"
+        />
+        <button id="searchsubmit" type="submit" class="btn"><span>Search</span></button>
+      </form>
+    </div><!-- global-search -->
+  </div><!-- container -->
+</section>
+<section class="gtl-search-results-container">
+  <div class="container">
+
+    <?php if (!empty($response['results'])) : ?>
+      <?php foreach ($response['results'] as $result) : ?>
+
+        <?= apply_filters('gearlab/render', 'search-result.php', array_merge($data, [
+          'result' => $result,
+        ])) ?>
+
+      <?php endforeach; ?>
+    <?php endif; ?>
+
+    <div class="post-navigation">
+      <?= GearLab\paginate_links($response) ?>
+    </div>
+  </div>
+</section>

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -63,7 +63,7 @@
         value="<?= $data['gearlab_search_redirect'] ?>"
         placeholder="/search"
       />
-      <em>Do not include "?" or else redirects may not work properly.</em>
+      <em>Do not include "?" or else redirects may not work properly. The page you specify here must contain the shortcode above.</em>
     </p>
     <p>
       <input

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -1,24 +1,30 @@
 <form name="gearlab_tools_settings" method="post">
-  <div class="glt-label">
-    <label for="gearlab_api_key"><b>API Key</b></label>
-  </div>
-  <div class="glt-field">
-    <input type="text" id="gearlab_api_key" name="gearlab_api_key" value="<?= $data['gearlab_api_key'] ?>">
+  <div class="glt-field glt-field--flex">
+    <div class="glt-field__label">
+      <label for="gearlab_api_key"><b>API Key</b></label>
+    </div>
+    <div class="glt-field__input">
+      <input type="text" id="gearlab_api_key" name="gearlab_api_key" value="<?= $data['gearlab_api_key'] ?>">
+    </div>
   </div>
 
-  <div class="glt-label">
-    <label for="gearlab_collection_id"><b>Collection ID</b></label>
-  </div>
-  <div class="glt-field">
-    <input type="text" id="gearlab_collection_id" name="gearlab_collection_id" value="<?= $data['gearlab_collection_id'] ?>">
+  <div class="glt-field glt-field--flex">
+    <div class="glt-field__label">
+      <label for="gearlab_collection_id"><b>Collection ID</b></label>
+    </div>
+    <div class="glt-field__input">
+      <input type="text" id="gearlab_collection_id" name="gearlab_collection_id" value="<?= $data['gearlab_collection_id'] ?>">
+    </div>
   </div>
 
   <?php // TODO: configure a radio toggle between Staging/Live environments ?>
-  <div class="glt-label">
-    <label for="gearlab_base_uri"><b>Base URI</b></label>
-  </div>
-  <div class="glt-field">
-    <input type="text" id="gearlab_base_uri" name="gearlab_base_uri" value="<?= $data['gearlab_base_uri'] ?>">
+  <div class="glt-field glt-field--flex">
+    <div class="glt-field__label">
+      <label for="gearlab_base_uri"><b>Base URI</b></label>
+    </div>
+    <div class="glt-field__input">
+      <input type="text" id="gearlab_base_uri" name="gearlab_base_uri" value="<?= $data['gearlab_base_uri'] ?>">
+    </div>
   </div>
 
   <div class="glt-field">

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -22,11 +22,64 @@
   </div>
 
   <div class="glt-field">
+    <h3>Override WP Search</h3>
+    <p>Unless you have custom-built an integration, to get site-wide search you must enable one of the following options:</p>
     <p>
-      <input type="checkbox" id="gearlab_enabled" name="gearlab_search_enabled" value="1" <?= $data['gearlab_search_enabled'] === '1' ? 'checked' : '' ?>>
-      <label for="gearlab_enabled"><b>Override default WordPress search</b></label>
+      <input
+        type="radio"
+        id="gearlab-search-override-disabled"
+        name="gearlab_search_enabled"
+        value=""
+        <?= empty($data['gearlab_search_enabled']) ? 'checked' : '' ?>
+      />
+      <label for="gearlab-search-override-disabled"><b>Disable overrides</b></label>
+    </p>
+    <?php $searchRedirectEnabled = $data['gearlab_search_enabled'] === GEARLAB_OVERRIDE_METHOD_SHORTCODE; ?>
+    <p>
+      <input
+        type="radio"
+        id="gearlab-search-shortcode"
+        name="gearlab_search_enabled"
+        value="<?= GEARLAB_OVERRIDE_METHOD_SHORTCODE ?>"
+        <?= $searchRedirectEnabled ? 'checked' : '' ?>
+      />
+      <label for="gearlab-search-shortcode"><b>Redirect searches to a specific page (Recommended)</b></label>
+    </p>
+    <p class="glt-redirect-url-field" <?= $searchRedirectEnabled ? '' : 'style="display:none"' ?>>
+      <label for="gearlab-search-page-redirect"><b>Redirect searches to:</b></label>
+      <input
+        type="text"
+        id="gearlab-search-page-redirect"
+        name="gearlab_search_redirect"
+        value="<?= $data['gearlab_search_redirect'] ?>"
+        placeholder="/search"
+      />
+      <em>Do not include "?" or else redirects may not work properly.</em>
+    </p>
+    <p>
+      <input
+        type="radio"
+        id="gearlab-search-timber"
+        name="gearlab_search_enabled"
+        value="<?= GEARLAB_OVERRIDE_METHOD_TIMBER ?>"
+        <?= $data['gearlab_search_enabled'] === GEARLAB_OVERRIDE_METHOD_TIMBER ? 'checked' : '' ?>
+      />
+      <label for="gearlab-search-timber"><b>Override default WordPress search template (Advanced - requires Timber plugin, or custom coding)</b></label>
     </p>
   </div>
+  <script>
+    jQuery(function($){
+
+      $('[name=gearlab_search_enabled]').click(function() {
+        if ($('[name=gearlab_search_enabled][value=shortcode]:checked').length) {
+          $('.glt-redirect-url-field').show();
+        } else {
+          $('.glt-redirect-url-field').hide();
+        }
+      });
+
+    });
+  </script>
 
   <div class="gtl-form-footer">
     <button type="submit" value="update_gearlab_settings" class="button button-primary">Save settings</button>

--- a/views/settings-meta.php
+++ b/views/settings-meta.php
@@ -23,7 +23,10 @@
 
   <div class="glt-field">
     <h3>Override WP Search</h3>
-    <p>Unless you have custom-built an integration, to get site-wide search you must enable one of the following options:</p>
+    <p>Use this shortcode on any page:</p>
+    <textarea class="glt-shortcode-text" disabled>[gearlab_search]</textarea>
+    <button type="button" class="button button-secondary glt-shortcode-copy">Copy to clipboard</button>
+    <p>Unless you have custom-built an integration, for your theme's normal search form to work, you must enable one of the following options:</p>
     <p>
       <input
         type="radio"
@@ -76,6 +79,21 @@
         } else {
           $('.glt-redirect-url-field').hide();
         }
+      });
+
+      $('.glt-shortcode-copy').click(function(e) {
+        e.preventDefault();
+
+        // copy shortcode text to clipboard
+        $textarea = $('.glt-shortcode-text');
+        $textarea.attr('disabled', false);
+        $textarea.get(0).select();
+        document.execCommand('copy');
+        $textarea.attr('disabled', true);
+
+        var $btn = $(this);
+        var updatedText = $btn.text() === 'Copied!' ? 'Copied again!' : 'Copied!';
+        $(this).text(updatedText);
       });
 
     });

--- a/wp-api.php
+++ b/wp-api.php
@@ -27,7 +27,17 @@ function completions(array $params) : array {
 }
 
 function search_enabled() : bool {
-  return apply_filters('gearlab/search/enabled', get_option('gearlab_search_enabled') === '1');
+  return apply_filters(
+    'gearlab/search/enabled',
+    get_option('gearlab_search_enabled') === GEARLAB_OVERRIDE_METHOD_TIMBER
+  );
+}
+
+function shortcode_redirect_enabled() : bool {
+  return apply_filters(
+    'gearlab/search_shortcode/enabled',
+    get_option('gearlab_search_enabled') === GEARLAB_OVERRIDE_METHOD_SHORTCODE
+  );
 }
 
 function paginate_links(array $response) : string {


### PR DESCRIPTION
**Not ready for primetime yet**, but the shortcode portion should at least work.

TODO:

- [x] build out Settings option for selecting the page where the shortcode lives
- [x] redirect all `?s=...` requests to the search page (selected in Settings, per above) - **should this be behind a feature flag?**
- [x] documentation